### PR TITLE
some workaround

### DIFF
--- a/tomighty-swing/pom.xml
+++ b/tomighty-swing/pom.xml
@@ -201,6 +201,18 @@
                     </reportPlugins>
                 </configuration>
             </plugin>
+            
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.0.2</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+            
         </plugins>
     </build>
 


### PR DESCRIPTION
small fix for compiling tomighty-swing.
without this fix maven won't compile package on my machine (ubuntu 12.10) and thorwing this error:
use -source 5 or higher to enable **some_stuff**

I don't know is this some kind of my environment config errors, or missing in pom.xml file but with this fix tomighty compiled successfully
